### PR TITLE
newparse strips the path from inputfilename if outputdirectory is given

### DIFF
--- a/src/main/C/newparse/newparse.cpp
+++ b/src/main/C/newparse/newparse.cpp
@@ -94,7 +94,9 @@ int main(int argc, char ** argv) {
     string rname = here;
     if (strstr(here, ".gz") - here == strlen(here) - 3) {
       rname = rname.substr(0, strlen(here) - 3);
-    } 
+    }
+    // if outputdir given, this strips path from inputfile
+    if (odname.size() != 0) rname = rname.substr(rname.find_last_of("\\/")+1);
     writeIntVec(tokens, odname+rname+".imat"+suffix, membuf);
     tokens.clear();
     numlines = 0;


### PR DESCRIPTION
newparse.cpp for xmltweet.exe
Solves issue #33 