### PR TITLE
Mh test updater

### DIFF
--- a/src/main/scala/BIDMach/models/GLM.scala
+++ b/src/main/scala/BIDMach/models/GLM.scala
@@ -187,13 +187,23 @@ class GLM(opts:GLM.Opts) extends RegressionModel(opts) {
   
   def meval2(in:Mat, targ:Mat):FMat = meval3(in, targ, null)
   
+  /**
+   * This runs the actual score computation, typically average log likelihood. 
+   * Note that this isn't part of the super class (Regression.scala).
+   * 
+   * @param in The input matrix for this minibatch.
+   * @param targ The target matrix (usually vector) for this minibatch, if any.
+   * @param dweights The weights for this minibatch, if any (often null).
+   */
   def meval3(in:Mat, targ:Mat, dweights:Mat):FMat = {
     val ftarg = if (targ.asInstanceOf[AnyRef] != null) full(targ) else null;
     val targs = if (targmap.asInstanceOf[AnyRef] != null && ftarg.asInstanceOf[AnyRef] != null) targmap * ftarg else ftarg;
     val eta = if (hashFeatures > 0) GLM.hashMult(modelmats(0), in, opts.hashBound1, opts.hashBound2) else modelmats(0) * in;
     GLM.preds(eta, eta, mylinks, totflops);
     if (ogmats != null) {ogmats(0) = eta;}
+
     if (targs.asInstanceOf[AnyRef] != null) {
+      // A row vector of log likelihood scores.
     	val v = GLM.llfun(eta, targs, mylinks, totflops);
     	if (dweights.asInstanceOf[AnyRef] != null) {
     		FMat(sum(v ∘  dweights, 2) / sum(dweights))
@@ -201,7 +211,12 @@ class GLM(opts:GLM.Opts) extends RegressionModel(opts) {
     	  if (opts.doVariance) {
     	    FMat(mean(v, 2)) on FMat(variance(v, 2));
     	  } else {
-    	  	FMat(mean(v, 2));
+    	    // For the MH test, we need individual scores.
+    	    if (opts.matrixOfScores) {
+    	      FMat(v) 
+    	    } else {
+    	  	  FMat(mean(v, 2));
+    	    }
     	  }
     	}
     } else {
@@ -221,6 +236,7 @@ object GLM {
     var hashBound1:Int = 1000000;
     var hashBound2:Int = 1000000;
     var aopts:ADAGrad.Opts = null;
+    var matrixOfScores = false;
   }
   
   val linear = 0;

--- a/src/main/scala/BIDMach/updaters/MHTest.scala
+++ b/src/main/scala/BIDMach/updaters/MHTest.scala
@@ -62,7 +62,11 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
         (opts.nn2l, opts.n2lsigma))
     n2ld = norm2logdata(?,0) \ cumsum(norm2logdata(?,1))
 
-    for (i <- 0 until modelmats.length) {
+    val nmats = modelmats.length;
+    deltaTheta = new Array[Mat](nmats)
+    proposedTheta = new Array[Mat](nmats)
+    tmpTheta = new Array[Mat](nmats)
+    for (i <- 0 until nmats) {
       deltaTheta(i) = modelmats(i).zeros(modelmats(i).nrows, modelmats(i).ncols)
       proposedTheta(i) = modelmats(i).zeros(modelmats(i).nrows, modelmats(i).ncols)
       tmpTheta(i) = modelmats(i).zeros(modelmats(i).nrows, modelmats(i).ncols)
@@ -131,6 +135,7 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
     }
     // If sample variance is too large, we cannot run the test.
     else if (sampleVariance >= targetVariance) {
+      println("too large")
       if (ipass > 0 && b == N) {
         println("WARNING: test used entire dataset but variance is still too high.")
         println("  sample variance: %f, num std = %f" format (sampleVariance, numStd))
@@ -148,7 +153,12 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
       newMinibatch = true
       val Xn = dnormrnd(0, math.sqrt(targetVariance-sampleVariance), 1, 1).dv
       val Xc = normlogrnd(1,1).dv
-      if (deltaStar + Xn + Xc > 0) accept = true
+      if (deltaStar + Xn + Xc > 0) {
+        accept = true
+        println("we have accepted!!")
+      } else {
+        println("reject!!")
+      }
     }
 
     // Reset parameters if the proposal was rejected or if we need more data.
@@ -216,7 +226,7 @@ object MHTest {
 
   trait Opts extends Updater.Opts {
     val N = 100000
-    val T = 1
+    val T = 1000
     val Nknown = true
     val n2lsigma = 0.9f
     val nn2l = 2000

--- a/src/main/scala/BIDMach/updaters/MHTest.scala
+++ b/src/main/scala/BIDMach/updaters/MHTest.scala
@@ -1,0 +1,243 @@
+package BIDMach.updaters
+ 
+import BIDMat.{Mat,SBMat,CMat,DMat,FMat,IMat,HMat,GMat,GIMat,GSMat,SMat,SDMat,TMat}
+import BIDMat.MatFunctions._
+import BIDMat.SciFunctions._
+import BIDMach.models._
+import edu.berkeley.bid.CUMACH
+
+/**
+ * Our fast MH test. See:
+ *
+ *  An Efficient Minibatch Acceptance Test for Metropolis-Hastings, arXiv 2016
+ *  Haoyu Chen, Daniel Seita, Xinlei Pan, John Canny
+ *
+ * This is a work in progress. For now assume a simple matrix as the data
+ * source, or row vectors if dealing with vectors. Current issues:
+ * 
+ * 1. Since the update relies on minibatches, I assume we can start with the
+ * minibatch provided by BIDMach on a given iteration. But how to get the next
+ * one? If we can peek ahead and add the next datasource's minibatch, won't that
+ * added minibatch also be what BIDMach provides as the starting minibatch for
+ * the next iteration?
+ * 
+ * 2. Where can we get information about the log likelihood of the elements? We
+ * need `log p(x_i*|theta)` and `log p(x_i*|theta)` for all minibatch elements.
+ * Is this model.evalfun?
+ * 
+ * 3. Do we ignore updatemats?
+ * 
+ * 4. Where can we extract information about temperature?
+ * 
+ * 5. Later, how to extend this to the GPU case and save on memory?
+ */
+class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater {
+
+  // Put null stuff here that we initialize later. I'm not sure how much of this we need.
+  var modelmats:Array[Mat] = null
+  var updatemats:Array[Mat] = null
+  var minibatch:Array[Mat] = null
+  //var dsource:Datasource = null
+
+  var theta:Mat = null
+  var ttheta:Mat = null
+  var thetaLogL:Mat = null
+  var tthetaLogL:Mat = null
+  var diff:Mat = null
+  var thetaArrayMat:Array[Mat] = null
+
+  var delta:Mat = null
+  var n2ld:DMat = null
+
+
+  /**
+   * I think we need the model to get minibatches of data.
+   */
+  override def init(model0:Model) = {
+    model = model0;
+    modelmats = model.modelmats
+    updatemats = model.updatemats
+    val mm = modelmats(0)
+
+    theta = mm.zeros(mm.nrows, mm.ncols)
+    ttheta = mm.zeros(mm.nrows, mm.ncols)
+    delta = mm.zeros(mm.nrows, mm.ncols)
+    thetaArrayMat = new Array[Mat](1)
+
+    val norm2logdata = loadDMat("norm2log%d_20_%2.1f.txt" format 
+        (opts.nn2l, opts.n2lsigma))
+    n2ld = norm2logdata(?,0) \ cumsum(norm2logdata(?,1))
+    
+    //data = model.datasource
+  }
+
+
+  /**
+   * This performs the update and the MH test.
+   *
+   * @param ipass The current pass over the full (training) data.
+   * @param step Progress within the current minibatch, indicated as a numerical
+   * 		index representing the starting column of this minibatch.
+   * @param gprogress The percentage progress overall, when considering the
+   *    datasource size and the number of (training) passes.
+   */
+  override def update(ipass:Int, step:Long, gprogress:Float):Unit = {
+    ttheta = proposer(theta, delta)
+    var logu = ln(rand(1,1)).v;
+    var done = false
+    var mbStep = 100 // indicates how many elements in current minibatch
+    var mbSize = 100 // indicates amount to increment minibatch size
+
+    do {
+      // Extract minibatch of data somehow. It has type Array[Mat], not Mat.
+      // extract from column indices `step` to `step+mbStep`
+      minibatch = null // TODO
+      
+      // Evaluate log likelihoods. I think `step` as third argument is OK.
+      thetaLogL = model.evalbatch(minibatch, ipass, step)
+      thetaArrayMat(0) = ttheta
+      model.setmodelmats(thetaArrayMat)
+      tthetaLogL = model.evalbatch(minibatch, ipass, step)
+
+      // multiply diff by (N/T) to scale for data size and temperature?
+      diff = thetaLogL - tthetaLogL
+
+      // Then run the test with our minibatch
+      val (moved,takeStep) = testFunction(diff, logu, false)
+      done = moved
+      
+      if (done) {
+        // TODO Record some statistics. Note that we already set the model to
+        // have the new theta, so if we don't move, revert to the old theta.
+        if (!takeStep) {
+          thetaArrayMat(0) = theta
+          model.setmodelmats(thetaArrayMat)
+        }
+      } else {
+        // Increase the minibatch size 
+        if (opts.fasterIncreaseUse) {
+          mbStep = (mbStep*opts.fasterIncreaseFactor).toInt
+        } else {
+          mbStep += mbSize
+        }
+      }
+
+    } while (!done)
+  }
+  
+
+  /**
+   * This will run the actual test function.
+   * 
+   * @param diff A vector containing scaled log likelihood ratios for each
+   *    element in the minibatch
+   * @param logu The \psi(u,theta,theta') term, which is log(u) for symmetric
+	 *    proposals that we use.
+	 * @param full A boolean indicating if this minibatch is equivalent to the
+	 * 		full data. This should ideally be false always.
+	 * @return A boolean (b1,b2) where b1=true means done, otherwise increase
+	 * 		minibatch size, and b2=true means we moved to the new theta, otherwise
+	 * 		stick with old theta.
+   */
+  def testFunction(diff:Mat, logu:Double, full:Boolean):(Boolean,Boolean) = {
+    val tvar = variance(diff).dv/diff.length;
+    val targvar = opts.n2lsigma * opts.n2lsigma;
+    val x = mean(diff).dv;
+    val ns = x / math.sqrt(tvar);
+    
+    if (math.abs(ns) > 5) {
+      // Get abnormally large |ns| values out of the way.
+      if (ns > 0) (true, true) else (true, false)
+    } else {
+      if (tvar >= targvar) {
+        // If tvar >= targvar, we need to decrease sample variance of data.
+        if (full) { 
+          if (opts.continueDespiteFull) {
+            println("Warning: test failed variance condition, var=%f nstd = %f" 
+                format (tvar, ns));
+            if (x > 0) (true, true) else (true, false)
+          } else {
+            throw new RuntimeException("Test failed variance condition, var=%f, nstd = %f" 
+                format (tvar, ns))
+          }
+        } else {
+          (false, false)
+        }
+      } else {
+        // Otherwise, we can run our test.
+        val xn = dnormrnd(0, math.sqrt(targvar-tvar), 1, 1).dv
+        val xc = normlogrnd(1,1).dv
+        if ((x + xn + xc) > 0) {
+          (true, true)
+        } else {
+          (true, false)
+        }
+      }
+    }
+  }
+  
+   
+  /**
+   * A proposer, which is currently the simple random walk but we should try and
+   * see if we can do something fancier.
+   * 
+   * @param t Our current theta.
+   * @param d Container to hold sampled noise.
+   */
+  def proposer(t:Mat, d:Mat) = {
+    normrnd(0, opts.sigmaProposer, d)
+    t+d
+  }
+  
+  
+  /**
+   * Randomly generate sample(s) from the correction distribution X_c. It
+   * samples values in (0,1) and then finds the x-positions (in some bounded
+   * range such as [-10,10]) corresponding to those CDF values in X_c.
+   * 
+   * @param m Number of rows of random samples.
+   * @param n Number of columns of random samples.
+   */
+  def normlogrnd(m:Int, n:Int):DMat = {
+    val rr = drand(m, n)
+    var i = 0
+    while (i < rr.length) {
+      val rv = rr.data(i)
+      var top = n2ld.nrows
+      var bottom = 0
+      while (top - bottom > 1) {
+        val mid = (top + bottom) / 2
+        if (rv > n2ld(mid, 1)) {
+          bottom = mid;
+        } else {
+          top = mid
+        }
+      }
+      val y0 = n2ld(bottom, 1)
+      val y1 = n2ld(math.min(top, n2ld.nrows-1), 1)
+      val alpha = if (y1 != y0) ((rv - y0) / (y1 - y0)) else 0.0
+      val x0 = n2ld(bottom, 0)
+      val x1 = n2ld(math.min(top, n2ld.nrows-1), 0)
+      val newx = alpha * x1 + (1-alpha) * x0
+      rr.data(i) = newx
+      i += 1
+    }
+    rr
+  }
+ 
+}
+
+
+object MHTest {
+
+  trait Opts extends Updater.Opts {
+    val fasterIncreaseUse = false
+    val fasterIncreaseFactor = 2.0
+    val n2lsigma = 0.9
+    val nn2l = 2000
+    val sigmaProposer = 0.05
+    val continueDespiteFull = true
+  }
+ 
+  class Options extends Opts {}
+}

--- a/src/main/scala/BIDMach/updaters/MHTest.scala
+++ b/src/main/scala/BIDMach/updaters/MHTest.scala
@@ -32,8 +32,9 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
   var proposedTheta:Array[Mat] = null  // The proposed theta.
   var modelmats:Array[Mat] = null      // The current theta.
   var updatemats:Array[Mat] = null     // Contains gradients (not currently used).
-  var scores0:FMat = null              // Container for (N/T)*\log p(x_i*|theta) terms.
-  var scores1:FMat = null              // Container for (N/T)*\log p(x_i*|theta') terms.
+  var scores0:FMat = null              // Container for (N/T)*log p(x_i*|theta) terms.
+  var scores1:FMat = null              // Container for (N/T)*log p(x_i*|theta') terms.
+  var lRatios:FMat = null              // Holds (N/T)*log(ratio) across FULL minibatch.
 
   var newMinibatch:Boolean = true      // Whether we should run the proposer.
   var b:Long = 0                       // Current minibatch size (also `b` in the paper).
@@ -45,18 +46,33 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
   var T:Int = opts.T                   // The temperature of the distribution.
 
 
-  /** Standard initialization. */
+  /** 
+   * Standard initialization. We have:
+   * 
+   * - modelmats (i.e. \theta) is initialized to a random walk
+   * - n2ld loads the pre-computed X_c variable distribution
+   * - {delta,proposed,tmp}Theta initialized to zeros to start
+   * 
+   * Note that the file for the norm2logdata should be in the correct directory.
+   */
   override def init(model0:Model) = {
     model = model0;
     modelmats = model.modelmats
     updatemats = model.updatemats
     scores0 = zeros(1,model.datasource.opts.batchSize)
     scores1 = zeros(1,model.datasource.opts.batchSize)
+
+    for (i <- 0 until modelmats.length) {
+      normrnd(0, opts.sigmaProposer, modelmats(i))
+    }
+    
     if (opts.Nknown) {
       N = opts.N
     } else {
       println("WARNING: opts.Nknown=false. (For now it should be true.)")
+      throw new RuntimeException("Aborting now.")
     }
+    lRatios = zeros(1,opts.N)
     
     val norm2logdata = loadDMat("norm2log%d_20_%2.1f.txt" format 
         (opts.nn2l, opts.n2lsigma))
@@ -66,6 +82,7 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
     deltaTheta = new Array[Mat](nmats)
     proposedTheta = new Array[Mat](nmats)
     tmpTheta = new Array[Mat](nmats)
+
     for (i <- 0 until nmats) {
       deltaTheta(i) = modelmats(i).zeros(modelmats(i).nrows, modelmats(i).ncols)
       proposedTheta(i) = modelmats(i).zeros(modelmats(i).nrows, modelmats(i).ncols)
@@ -93,6 +110,13 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
     // If we're starting a new minibatch, need to reset a bunch of values.
     if (newMinibatch) {
       randomWalkProposer()
+      if (opts.verboseMH) {
+        println("\nNEW MINIBATCH!!!")
+        println("after random walk, have:")
+        println("\ttheta(0->10) = " +modelmats(0)(0 -> 10))
+        println("\tttheta(0->10) = " +proposedTheta(0)(0 -> 10))
+        println("\tdelta_theta(0->10) = " +deltaTheta(0)(0 -> 10))
+      }
       logu = ln(rand(1,1)).v
       newMinibatch = false
       b = 0
@@ -100,42 +124,68 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
       avgLogLL0 = 0f
       avgLogLL1 = 0f
       for (i <- 0 until modelmats.length) {
-        tmpTheta(i) = modelmats(i)
+        tmpTheta(i) = modelmats(i) + 0
       }
+      lRatios.clear
     }
     b += model.datasource.opts.batchSize
     n += 1.0f
 
-    // Compute \Delta* (deltaStar) for our MH test using the current batch.
-    // Doing so requires getting scores of omats, hence model.evalbatchg.
-    // And this also has to be done twice, one for theta, one for theta'.
-    // We require the variance, hence need a vector, and will exit if not.
+    /*
+     * Compute \Delta* (deltaStar) for our MH test using the current batch.
+     * Doing so requires getting scores of omats, hence model.evalbatchg.
+     * And this also has to be done twice, one for theta, one for theta'.
+     * We require the variance, hence need a vector, and will exit if not.
+     * For variance, my workaround is to store the individuals in `lRatios`.
+     * Don't forget to divide by b due to the CLT assumption of \Delta*.
+     */
     
     scores0 = model.evalbatchg(model.datasource.omats, ipass, step) * (N/T.dv)
     if (scores0.length == 1) {
       throw new RuntimeException("Need individual scores, but getting a scalar.")
     }
     for (i <- 0 until modelmats.length) {
-      modelmats(i) = proposedTheta(i)
+      modelmats(i) = proposedTheta(i) + 0
     }
     scores1 = model.evalbatchg(model.datasource.omats, ipass, step) * (N/T.dv)
     avgLogLL0 = ((n-1)/n)*avgLogLL0 + mean(scores0,2).v/n
     avgLogLL1 = ((n-1)/n)*avgLogLL1 + mean(scores1,2).v/n
-
-    val deltaStar = (avgLogLL0-avgLogLL1) - logu
-    val sampleVariance = variance(scores1-scores0).v / scores0.length // Divide due to CLT
+    val deltaStar = (avgLogLL1 - avgLogLL0) - logu
+    val indices:IMat = irow((b - model.datasource.opts.batchSize).toInt until b.toInt)
+    lRatios(indices) = (scores1 - scores0)
+    val sampleVariance = variance(lRatios(0 until b.toInt)).v / b.toFloat
+    
+    // Now proceed with test. First, a few important values:
     val targetVariance = opts.n2lsigma * opts.n2lsigma
     val numStd = deltaStar / math.sqrt(sampleVariance)
     var accept = false
     
+    if (opts.verboseMH) {
+      println("b="+b+", n="+n+", logu="+logu+ ", b-mbSize="+(b - model.datasource.opts.batchSize).toInt)
+      println("scores0(0->10) = " +scores0(0 -> 10))
+      println("scores1(0->10) = " +scores1(0 -> 10))
+      println("lRatios(0->10) = " +lRatios(0 -> 10))
+      println("mean(scores0) = "+mean(scores0,2).dv+", mean(scores1) = "+mean(scores1,2).dv)
+      println("avgLogLL0 = "+avgLogLL0+", avgLogLL1 = "+avgLogLL1)
+      println("sampleVar = " +sampleVariance)
+      println("delta* = " + deltaStar)
+    }
+
     // Take care of abnormally good or bad minibatches (can probably be deleted).
     if (math.abs(numStd) > 5.0) {
+      if (opts.verboseMH) {
+        println("\tCASE 1: math.abs(numStd) = " +math.abs(numStd))
+      }
       newMinibatch = true
-      if (numStd > 0) accept = true
+      if (numStd > 0) {
+        accept = true
+      }
     }
     // If sample variance is too large, we cannot run the test.
     else if (sampleVariance >= targetVariance) {
-      println("too large")
+      if (opts.verboseMH) {
+        println("\tCASE 2: sample >= target = "+targetVariance)
+      }
       if (ipass > 0 && b == N) {
         println("WARNING: test used entire dataset but variance is still too high.")
         println("  sample variance: %f, num std = %f" format (sampleVariance, numStd))
@@ -153,18 +203,24 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
       newMinibatch = true
       val Xn = dnormrnd(0, math.sqrt(targetVariance-sampleVariance), 1, 1).dv
       val Xc = normlogrnd(1,1).dv
-      if (deltaStar + Xn + Xc > 0) {
+      val testStat = deltaStar + Xn + Xc
+      if (opts.verboseMH) {
+        println("\tCASE 3; with testStat = "+testStat)
+      }
+      if (testStat > 0) {
         accept = true
-        println("we have accepted!!")
-      } else {
-        println("reject!!")
       }
     }
 
-    // Reset parameters if the proposal was rejected or if we need more data.
-    if (!accept) {
+    // Reset parameters appropriately.
+    if (accept) {
       for (i <- 0 until modelmats.length) {
-        modelmats(i) = tmpTheta(i)
+        tmpTheta(i) = modelmats(i) + 0 // tmpTheta contains proposed theta
+      }     
+    }
+    else{
+      for (i <- 0 until modelmats.length) {
+        modelmats(i) = tmpTheta(i) + 0 // modelmats reset back to old theta
       }
     }
   }
@@ -179,7 +235,11 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
   def randomWalkProposer() = {
     for (i <- 0 until modelmats.length) {
       normrnd(0, opts.sigmaProposer, deltaTheta(i))
-      proposedTheta(i) ~ modelmats(i) + deltaTheta(i)
+      proposedTheta(i) = modelmats(i) + deltaTheta(i)
+      // I can't figure out why the following doesn't work.
+      //proposedTheta(i) ~ modelmats(i) + 0
+      //(this doesn't work either: proposedTheta(i) <-- modelmats(i) )
+      //proposedTheta(i) ~ proposedTheta(i) + deltaTheta(i)
     }
   }
  
@@ -225,13 +285,14 @@ class MHTest(override val opts:MHTest.Opts = new MHTest.Options) extends Updater
 object MHTest {
 
   trait Opts extends Updater.Opts {
-    val N = 100000
-    val T = 1000
-    val Nknown = true
-    val n2lsigma = 0.9f
-    val nn2l = 2000
-    val sigmaProposer = 0.05f
-    val continueDespiteFull = true
+    var N = 100000
+    var T = 1000
+    var Nknown = true
+    var n2lsigma = 0.9f
+    var nn2l = 2000
+    var sigmaProposer = 0.05f
+    var continueDespiteFull = true
+    var verboseMH = true
   }
  
   class Options extends Opts {}


### PR DESCRIPTION
A pull request for the MH test updater.

This just modifies the GLM.scala slightly to allow for an option to return the FMat of individual scores instead of automatically taking the mean.

The more substantial contribution is the MH Test updater itself. I will test this in more detail (it seems to work on the logistic regression example I was using).