### PR TITLE
fix newparse and getrcv1

### DIFF
--- a/scripts/getrcv1.sh
+++ b/scripts/getrcv1.sh
@@ -38,6 +38,12 @@ allfiles=${allfiles},lyrl2004_tokens_train.dat.gz
 # Get topic assignments
 ${WGET} http://www.ai.mit.edu/projects/jmlr/papers/volume5/lewis04a/a08-topic-qrels/rcv1-v2.topics.qrels.gz
 
+# Build parsing/tokenizing executables
+pushd ${BIDMACH_SCRIPTS}/../src/main/C/newparse
+./configure
+make && make install
+popd
+
 # Tokenize the text files
 # Windows cant use an uncompression pipe so uncompress here
 if [ "$OS" = "Windows_NT" ]; then

--- a/src/main/C/newparse/utils.cpp
+++ b/src/main/C/newparse/utils.cpp
@@ -59,15 +59,15 @@ void strtolower(char * str) {
 int checkword(char * str, strhash &htab, ivector &wcount, ivector &tokens, unhash &unh) {
   strtolower(str);
   int userno;
-  if (htab.count(str)) {
+  if (htab.count(str) > 0) {
     userno = htab[str];
-    wcount[userno-1]++;
+    wcount[userno]++;
   } else {
     try {
       char * newstr = new char[strlen(str)+1];
       strcpy(newstr, str);
+      userno = wcount.size();
       wcount.push_back(1);
-      userno = unh.size();
       unh.push_back(newstr);
       htab[newstr] = userno;
     } catch (bad_alloc) {


### PR DESCRIPTION
Fixed a memory leak discovered via `valgrind`. (Breaking behavior on aarch64, somehow still worked on x86 though)