### PR TITLE
fix: fix runtime class cast exception/serialization issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 cbin
 lib/*.jar
 *.rej

--- a/src/main/scala/BIDMach/allreduce/GridLayout.scala
+++ b/src/main/scala/BIDMach/allreduce/GridLayout.scala
@@ -1,33 +1,33 @@
 package BIDMach.allreduce
 
-class GridGroup(val index: Integer, val dim: Integer){}
+case class GridGroup(val index: Integer, val dim: Integer){}
 
-class GridLayout(val scale: Integer, val dim: Integer) {
-  val total: Integer = scale * dim
-  type GridMember = Array[Integer]
+class GridLayout(val scale: Int, val dim: Int) {
+  val total: Int = Math.pow(scale, dim).toInt
+  type GridMember = Array[Int]
   private val members: Array[GridMember] = genMembers(dim)
 
-  private def genMembers(dim: Integer): Array[Array[Integer]] =  {
+  private def genMembers(dim: Int): Array[Array[Int]] =  {
     if(dim == 0){
       Array(Array())
     }
     else{
-      var ret: Array[Array[Integer]] = Array()
+      var ret: Array[Array[Int]] = Array()
       for(x <- genMembers(dim -1)){
         for(i <- 0 until scale){
-          ret :+= (x:+i).asInstanceOf[Array[Integer]]
-      }
+          ret :+= (x:+i)
+        }
       }
       ret
     }
   }
 
-  def members(group: GridGroup):Array[Integer]={
+  def members(group: GridGroup):Array[Int]={
     //given a group, return the members it have, O(total) naiive implemetation
-    var ret = Array[Integer]()
+    var ret = Array[Int]()
     for((member, i) <- members.zipWithIndex){
       if(member(group.dim) == group.index){
-        ret :+= i.asInstanceOf[Integer]
+        ret :+= i.asInstanceOf[Int]
       }
     }
     ret

--- a/src/main/scala/BIDMach/allreduce/GridMessages.scala
+++ b/src/main/scala/BIDMach/allreduce/GridMessages.scala
@@ -2,14 +2,8 @@ package BIDMach.allreduce
 
 import akka.actor.ActorRef
 
-//#messages
-// master messages
-final case class OrganizeGridWorker(text: String)
-final case class GridOrganizationFailed(reason: String, job: OrganizeGridWorker)
 
 // worker messages
-//final case class GridNeighborAddresses(addresses: Seq[ActorRef])
 final case class GridGroupAddresses(group: GridGroup, addresses: Set[ActorRef])
 final case class HelloFromGroup(text: String)
-case class GreetGroups()
-//#messages
+final case class GreetGroups()


### PR DESCRIPTION
3 small changes;
- Return "Future" of Done, when adding new member to the set, so that we know the map size has increased. Previously when this async adding member got executed, trying to compare the current size of worker failed as it still sees empty map.
- Change Integer to int, avoiding some cast exception
- Adding case class to the message, allowing for serialization