### PR TITLE
"Stats" reporting workers

### DIFF
--- a/scripts/testAllReduceGridMaster.scala
+++ b/scripts/testAllReduceGridMaster.scala
@@ -4,7 +4,7 @@ import scala.concurrent.duration._
 
 // Override the configuration of the port when specified as program argument
 val port = "2551"
-val nodeNum = 4;
+val nodeNum = 4
 val masterConfig = MasterConfig(nodeNum = nodeNum, discoveryTimeout = 5.seconds)
 
 AllreduceGridMaster.startUp(port, masterConfig)

--- a/scripts/testAllReduceNode.scala
+++ b/scripts/testAllReduceNode.scala
@@ -3,12 +3,12 @@ import BIDMach.allreduce._
 import scala.concurrent.duration._
 
 val dimNum = 2
-val dataSize = 100
-val maxChunkSize = 4
+val dataSize = 800000
+val maxChunkSize = 20000
 val workerPerNodeNum = 3
-val maxRound = 200
+val maxRound = 10000
 
-val threshold = ThresholdConfig(thAllreduce = 1f, thReduce = 1f, thComplete = 0.8f)
+val threshold = ThresholdConfig(thAllreduce = 1f, thReduce = 1f, thComplete = 1f)
 val metaData = MetaDataConfig(dataSize = dataSize, maxChunkSize = maxChunkSize)
 
 val nodeConfig = NodeConfig(dimNum = dimNum)
@@ -27,4 +27,4 @@ val lineMasterConfig = LineMasterConfig(
   metaData = metaData)
 
 
-AllreduceNode.startUp("0", nodeConfig,lineMasterConfig, workerConfig, assertCorrectness=false, checkpoint = 10)
+AllreduceNode.startUp("0", nodeConfig,lineMasterConfig, workerConfig, assertCorrectness=false, checkpoint = 100)

--- a/scripts/testAllReduceNode.scala
+++ b/scripts/testAllReduceNode.scala
@@ -11,10 +11,11 @@ val maxRound = 10000
 val threshold = ThresholdConfig(thAllreduce = 1f, thReduce = 1f, thComplete = 1f)
 val metaData = MetaDataConfig(dataSize = dataSize, maxChunkSize = maxChunkSize)
 
-val nodeConfig = NodeConfig(dimNum = dimNum)
+val nodeConfig = NodeConfig(dimNum = dimNum, reportStats = true)
 
 val workerConfig = WorkerConfig(
   discoveryTimeout = 5.seconds,
+  statsReportingRoundFrequency = 10,
   threshold = threshold,
   metaData = metaData)
 
@@ -27,4 +28,4 @@ val lineMasterConfig = LineMasterConfig(
   metaData = metaData)
 
 
-AllreduceNode.startUp("0", nodeConfig,lineMasterConfig, workerConfig, assertCorrectness=false, checkpoint = 100)
+AllreduceNode.startUp("0", nodeConfig,lineMasterConfig, workerConfig, assertCorrectness=false, checkpoint = 10)

--- a/src/main/scala/BIDMach/allreduce/AllreduceConfig.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceConfig.scala
@@ -23,10 +23,11 @@ case class LineMasterConfig(
                              threshold: ThresholdConfig,
                              metaData: MetaDataConfig)
 
-case class NodeConfig(dimNum: Int)
+case class NodeConfig(dimNum: Int, reportStats: Boolean)
 
 case class WorkerConfig(
                          discoveryTimeout: FiniteDuration,
+                         statsReportingRoundFrequency: Int = 10,
                          threshold: ThresholdConfig,
                          metaData: MetaDataConfig)
 

--- a/src/main/scala/BIDMach/allreduce/AllreduceDimensionNode.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceDimensionNode.scala
@@ -10,7 +10,7 @@ class AllreduceDimensionNode(
                               workerConfig: WorkerConfig,
                               sources: List[DataSource],
                               sinks: List[DataSink]
-                            ) extends Actor with akka.actor.ActorLogging with AllreduceWorkerStatsAggregator {
+                            ) extends Actor with akka.actor.ActorLogging {
 
   var workers: Array[ActorRef] = Array.empty
   var lineMaster: Option[ActorRef] = None
@@ -24,12 +24,16 @@ class AllreduceDimensionNode(
       log.error(s"\n----DimensionNode!dim=${dim}: I AM NOT SUPPOSED TO RECEIVE MSGs")
   }
 
+  protected def workerClassProvider(): Class[_] = {
+    classOf[AllreduceWorker]
+  }
+
   def generateWorkers(): Unit = {
     workers = {
       val arr = new Array[ActorRef](lineMasterConfig.workerPerNodeNum)
       for (i <- 0 until lineMasterConfig.workerPerNodeNum) {
         val worker = context.actorOf(Props(
-          classOf[AllreduceWorker],
+          workerClassProvider(),
           workerConfig,
           sources(i),
           sinks(i)),

--- a/src/main/scala/BIDMach/allreduce/AllreduceDimensionNode.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceDimensionNode.scala
@@ -10,7 +10,7 @@ class AllreduceDimensionNode(
                               workerConfig: WorkerConfig,
                               sources: List[DataSource],
                               sinks: List[DataSink]
-                            ) extends Actor with akka.actor.ActorLogging {
+                            ) extends Actor with akka.actor.ActorLogging with AllreduceWorkerStatsAggregator {
 
   var workers: Array[ActorRef] = Array.empty
   var lineMaster: Option[ActorRef] = None

--- a/src/main/scala/BIDMach/allreduce/AllreduceMessage.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceMessage.scala
@@ -13,6 +13,8 @@ final case class CompleteAllreduce(srcId : Int, round : Int)
 final case class ScatterBlock(value : Array[Float], srcId : Int, destId : Int, chunkId : Int, round : Int)
 final case class ReduceBlock(value: Array[Float], srcId : Int, destId : Int, chunkId : Int, round : Int, count: Int)
 
+final case class AllreduceStats(outgoingFloats: Long, incomingFloats: Long)
+
 // GM to LM
 /**
   * TODO: Rename this for consistency.

--- a/src/main/scala/BIDMach/allreduce/AllreduceWorker.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceWorker.scala
@@ -1,13 +1,14 @@
 package BIDMach.allreduce
 
 
+import BIDMach.allreduce.AllreduceNode.{DataSink, DataSource}
 import BIDMach.allreduce.buffer.{ReducedDataBuffer, ScatteredDataBuffer}
 import akka.actor.{Actor, ActorRef, Terminated}
 
 
 class AllreduceWorker(config: WorkerConfig,
-                      dataSource: AllReduceInputRequest => AllReduceInput,
-                      dataSink: AllReduceOutput => Unit) extends Actor with akka.actor.ActorLogging with AllreduceWorkerStatsReporting {
+                      dataSource: DataSource,
+                      dataSink: DataSink) extends Actor with akka.actor.ActorLogging {
 
   val thReduce = config.threshold.thReduce
   val thComplete = config.threshold.thComplete
@@ -285,8 +286,8 @@ class AllreduceWorker(config: WorkerConfig,
     println(e, s"error in $location, $stackTrace")
   }
 
-  override def sendTo(recipient: ActorRef, msg: Any) = {
-    super.sendTo(recipient, msg)
+  protected def sendTo(recipient: ActorRef, msg: Any) = {
+    recipient ! msg
   }
 
 }

--- a/src/main/scala/BIDMach/allreduce/AllreduceWorkerStats.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceWorkerStats.scala
@@ -1,0 +1,112 @@
+package BIDMach.allreduce
+
+import BIDMach.allreduce.ReceivePipeline.{HandledCompletely, Inner}
+import akka.actor.ActorRef
+
+import scala.collection.mutable
+
+
+trait AllreduceWorkerStatsReporting extends ReceivePipeline {
+
+  val scatterInCount: mutable.HashMap[Int, Int] = mutable.HashMap[Int, Int]()
+  val reducedInCount: mutable.HashMap[Int, Int] = mutable.HashMap[Int, Int]()
+
+  val scatterOutCount: mutable.HashMap[Int, Int] = mutable.HashMap[Int, Int]()
+  val reducedOutCount: mutable.HashMap[Int, Int] = mutable.HashMap[Int, Int]()
+
+  val checkPoint = 10
+
+  def workerId: Int
+
+  def sendTo(recipient: ActorRef, msg: Any) = {
+    recipient ! msg
+    msg match {
+      case s: ScatterBlock => incr(scatterOutCount, s.value.size)
+      case r: ReduceBlock => incr(reducedOutCount, r.value.size)
+      case _ => Unit
+    }
+  }
+
+  pipelineInner {
+
+    case s: ScatterBlock => {
+      incr(scatterInCount, s.value.size)
+      Inner(s)
+    }
+    case r: ReduceBlock => {
+      incr(reducedInCount, r.value.size)
+      Inner(r)
+    }
+    case start: StartAllreduce => {
+
+      if (start.round % checkPoint == 0 && start.round > checkPoint) {
+        val totalFloatsOut: Long = aggrCount(scatterOutCount) + aggrCount(reducedOutCount)
+        val totalFloatsIn: Long = aggrCount(scatterInCount) + aggrCount(reducedInCount)
+        context.parent ! AllreduceStats(totalFloatsOut, totalFloatsIn)
+        reset(scatterInCount)
+        reset(reducedInCount)
+        reset(reducedOutCount)
+        reset(scatterOutCount)
+      }
+      Inner(start)
+    }
+  }
+
+  private def incr(counter: mutable.HashMap[Int, Int], key: Int): Unit = {
+    counter.update(key, counter.getOrElse(key, 0) + 1)
+  }
+
+  private def reset(counter: mutable.HashMap[Int, Int]): Unit = {
+    counter.clear()
+  }
+
+  private def aggrCount(counter: mutable.HashMap[Int, Int]): Long = {
+    counter.map(kv => kv._1 * kv._2).sum
+  }
+
+}
+
+
+trait AllreduceWorkerStatsAggregator extends ReceivePipeline {
+
+  var count = 0
+  var tic = System.currentTimeMillis()
+  var outgoingFloats: Long = 0
+  var incomingFloats: Long = 0
+
+  def throughputStats(floatSize: Long, secondElapsed: Double) = {
+    val bytes = floatSize * 4.0
+    val mBytes = bytes / 1.0e6
+    (mBytes, mBytes / secondElapsed)
+  }
+
+  def dim: Int
+
+  pipelineInner {
+    case stats: AllreduceStats =>
+      outgoingFloats += stats.outgoingFloats
+      incomingFloats += stats.incomingFloats
+
+      if (count % 100 == 0 && count > 100) {
+
+        val timeElapsed = (System.currentTimeMillis() - tic) / 1.0e3
+
+        val (outgoingMbytes, outgoingThroughput) = throughputStats(outgoingFloats, timeElapsed)
+        val (incomingMbytes, incomingThroughput) = throughputStats(incomingFloats, timeElapsed)
+
+        val reportOut = f"Dim$dim: Outgoing $outgoingMbytes%2.1f Mbytes in $timeElapsed%2.1f seconds at $outgoingThroughput%4.3f MBytes/sec"
+        val reportIn = f"Dim$dim: Incoming $incomingMbytes%2.1f Mbytes in $timeElapsed%2.1f seconds at $incomingThroughput%4.3f MBytes/sec"
+        println(s"----$reportOut\n----$reportIn")
+        count = 0
+        outgoingFloats = 0
+        incomingFloats = 0
+        tic = System.currentTimeMillis()
+      }
+
+      count += 1
+
+      HandledCompletely
+  }
+
+
+}

--- a/src/main/scala/BIDMach/allreduce/AllreduceWorkerStats.scala
+++ b/src/main/scala/BIDMach/allreduce/AllreduceWorkerStats.scala
@@ -14,7 +14,7 @@ trait AllreduceWorkerStatsReporting extends ReceivePipeline {
   val scatterOutCount: mutable.HashMap[Int, Int] = mutable.HashMap[Int, Int]()
   val reducedOutCount: mutable.HashMap[Int, Int] = mutable.HashMap[Int, Int]()
 
-  val checkPoint = 10
+  val checkPoint = 50
 
   def workerId: Int
 
@@ -74,20 +74,20 @@ trait AllreduceWorkerStatsAggregator extends ReceivePipeline {
   var outgoingFloats: Long = 0
   var incomingFloats: Long = 0
 
-  def throughputStats(floatSize: Long, secondElapsed: Double) = {
+  def dim: Int
+
+  private def throughputStats(floatSize: Long, secondElapsed: Double) = {
     val bytes = floatSize * 4.0
     val mBytes = bytes / 1.0e6
     (mBytes, mBytes / secondElapsed)
   }
-
-  def dim: Int
 
   pipelineInner {
     case stats: AllreduceStats =>
       outgoingFloats += stats.outgoingFloats
       incomingFloats += stats.incomingFloats
 
-      if (count % 100 == 0 && count > 100) {
+      if (count % 10 == 0 && count > 10) {
 
         val timeElapsed = (System.currentTimeMillis() - tic) / 1.0e3
 

--- a/src/main/scala/BIDMach/allreduce/ReceivePipeline.scala
+++ b/src/main/scala/BIDMach/allreduce/ReceivePipeline.scala
@@ -1,0 +1,118 @@
+package BIDMach.allreduce
+
+import akka.actor.Actor
+
+/**
+  * Pattern of allowing actor to intercept message. Code is directly from here
+  * https://github.com/akka/akka/blob/master/akka-contrib/src/main/scala/akka/contrib/pattern/ReceivePipeline.scala
+  */
+object ReceivePipeline {
+  /**
+    * Result returned by an interceptor PF to determine what/whether to delegate to the next inner interceptor
+    */
+  sealed trait Delegation
+
+  case class Inner(transformedMsg: Any) extends Delegation {
+    /**
+      * Add a block of code to be executed after the message (which may be further transformed and processed by
+      * inner interceptors) is handled by the actor's receive.
+      *
+      * The block of code will be executed before similar blocks in outer interceptors.
+      */
+    def andAfter(after: ⇒ Unit): Delegation = InnerAndAfter(transformedMsg, (_ ⇒ after))
+  }
+
+  private[ReceivePipeline] case class InnerAndAfter(transformedMsg: Any, after: Unit ⇒ Unit) extends Delegation
+
+  /**
+    * Interceptor return value that indicates that the message has been handled
+    * completely. The message will not be passed to inner interceptors
+    * (or to the decorated actor's receive).
+    */
+  case object HandledCompletely extends Delegation
+
+  private def withDefault(interceptor: Interceptor): Interceptor = interceptor.orElse({ case msg ⇒ Inner(msg) })
+
+  type Interceptor = PartialFunction[Any, Delegation]
+
+  private sealed trait HandlerResult
+  private case object Done extends HandlerResult
+  private case object Undefined extends HandlerResult
+
+  private type Handler = Any ⇒ HandlerResult
+}
+
+/**
+  * Trait implementing Receive Pipeline Pattern. Mixin this trait
+  * for configuring a chain of interceptors to be applied around
+  * Actor's current behavior.
+  */
+trait ReceivePipeline extends Actor {
+  import ReceivePipeline._
+
+  private var pipeline: Vector[Interceptor] = Vector.empty
+  private var decoratorCache: Option[(Receive, Receive)] = None
+
+  /**
+    * Adds an inner interceptor, it will be applied lastly, near to Actor's original behavior
+    * @param interceptor an interceptor
+    */
+  def pipelineInner(interceptor: Interceptor): Unit = {
+    pipeline :+= withDefault(interceptor)
+    decoratorCache = None
+  }
+  /**
+    * Adds an outer interceptor, it will be applied firstly, far from Actor's original behavior
+    * @param interceptor an interceptor
+    */
+  def pipelineOuter(interceptor: Interceptor): Unit = {
+    pipeline +:= withDefault(interceptor)
+    decoratorCache = None
+  }
+
+  private def combinedDecorator: Receive ⇒ Receive = { receive ⇒
+    // So that reconstructed Receive PF is undefined only when the actor's
+    // receive is undefined for a transformed message that reaches it...
+    val innerReceiveHandler: Handler = {
+      case msg ⇒ receive.lift(msg).map(_ ⇒ Done).getOrElse(Undefined)
+    }
+
+    val zipped = pipeline.foldRight(innerReceiveHandler) { (outerInterceptor, innerHandler) ⇒
+      outerInterceptor.andThen {
+        case Inner(msg)                ⇒ innerHandler(msg)
+        case InnerAndAfter(msg, after) ⇒ try innerHandler(msg) finally after(())
+        case HandledCompletely         ⇒ Done
+      }
+    }
+
+    toReceive(zipped)
+  }
+
+  private def toReceive(handler: Handler) = new Receive {
+    def isDefinedAt(m: Any): Boolean = evaluate(m) != Undefined
+    def apply(m: Any): Unit = evaluate(m)
+
+    override def applyOrElse[A1 <: Any, B1 >: Unit](m: A1, default: A1 ⇒ B1): B1 = {
+      val result = handler(m)
+
+      if (result == Undefined) default(m)
+    }
+
+    private def evaluate(m: Any) = handler(m)
+  }
+
+  /**
+    * INTERNAL API.
+    */
+  override def aroundReceive(receive: Receive, msg: Any): Unit = {
+    def withCachedDecoration(decorator: Receive ⇒ Receive): Receive = decoratorCache match {
+      case Some((`receive`, cached)) ⇒ cached
+      case _ ⇒
+        val decorated = decorator(receive)
+        decoratorCache = Some((receive, decorated))
+        decorated
+    }
+
+    super.aroundReceive(withCachedDecoration(combinedDecorator), msg)
+  }
+}


### PR DESCRIPTION
- Create traits that intercept incoming and outgoing messages, count and aggregate them at round-worker, and send this local stats to the dimension node to be finally aggregated and reported. This is mostly in file: `AllreduceWorkerStats.scala`
- No significant changes in the old classes of allreduceworker
- This stats reporting is now configurable, and stats for now are just counts of message floats
- `ReceivePipeline` class is a copy from akka support for incoming message intercept, now deprecated in akk2.5. https://doc.akka.io/docs/akka/2.4-M1/contrib/receive-pipeline.html